### PR TITLE
Dockerfile: ubuntu base image architecture added

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM  armhf/ubuntu:16.04
 LABEL maintainer "Pierre Ugaz <ulm0@innersea.xyz>"
 ENV LANG=C.UTF-8
 SHELL ["/bin/sh", "-c"],


### PR DESCRIPTION
To build your image on a Rock Pi 4 running an aarch64 architecture I had to add the armhf architecture in the Dockerfile.
